### PR TITLE
不要なファイル群の生成を制限

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -11,5 +11,10 @@ module ChatSpace
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration should go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded.
+    config.generators do |g|
+      g.coffee  false
+      g.helper  false
+      g.test_framework  false
+    end
   end
 end


### PR DESCRIPTION
#WHAT
rails gコマンドを実行時、不要なファイル群を生成しないよう修正

#WHY
データの軽量化のため