### PR TITLE
サインアップ機能の追加

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,3 +1,8 @@
 class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
+  before_action :configure_permitted_parameters, if: :devise_controller?
+
+  def configure_permitted_parameters
+    devise_parameter_sanitizer.permit(:sign_up, keys: [:name])
+  end
 end

--- a/app/views/messages/index.html.haml
+++ b/app/views/messages/index.html.haml
@@ -2,7 +2,8 @@
 .contents
   .contents__side-content
     .contents__side-content__user
-      %h5 seo
+      %h5
+        = current_user.name
       .contents__side-content__user__icons
         %a.contents__side-content__user__icons--pencil
           %i.fa.fa-pencil-square-o

--- a/db/migrate/20170119104023_add_name_to_users.rb
+++ b/db/migrate/20170119104023_add_name_to_users.rb
@@ -1,0 +1,5 @@
+class AddNameToUsers < ActiveRecord::Migration[5.0]
+  def change
+    add_column :users, :name, :text, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,21 +10,22 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170119064330) do
+ActiveRecord::Schema.define(version: 20170119104023) do
 
   create_table "users", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
-    t.string   "email",                  default: "", null: false
-    t.string   "encrypted_password",     default: "", null: false
+    t.string   "email",                                default: "", null: false
+    t.string   "encrypted_password",                   default: "", null: false
     t.string   "reset_password_token"
     t.datetime "reset_password_sent_at"
     t.datetime "remember_created_at"
-    t.integer  "sign_in_count",          default: 0,  null: false
+    t.integer  "sign_in_count",                        default: 0,  null: false
     t.datetime "current_sign_in_at"
     t.datetime "last_sign_in_at"
     t.string   "current_sign_in_ip"
     t.string   "last_sign_in_ip"
-    t.datetime "created_at",                          null: false
-    t.datetime "updated_at",                          null: false
+    t.datetime "created_at",                                        null: false
+    t.datetime "updated_at",                                        null: false
+    t.text     "name",                   limit: 65535,              null: false
     t.index ["email"], name: "index_users_on_email", unique: true, using: :btree
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true, using: :btree
   end


### PR DESCRIPTION
#WHAT
・usersテーブルにnul制約をつけたnameカラムを追加
・nameの保存を許可するよう追記
・indexにログイン中のユーザの名前を反映

#WHY
ユーザ管理の実装に際して必要になる機能である為