### PR TITLE
メンバー追加の非同期通信化

### DIFF
--- a/app/assets/javascripts/group.js
+++ b/app/assets/javascripts/group.js
@@ -1,18 +1,35 @@
 $(function() {
+// 以下、検索結果の表示に関する記述
   function insertHTML(user) {
     var html = `
-      <div class="chat-group-form__chat-group-user search ">
+      <div class="chat-group-form__chat-group-user search">
         <p class="chat-group-form__chat-group-user__name">
           ${user.name}
         </p>
-        <a id="add_btn" class="chat-group-form__chat-group-user__btn">
+        <a id= "add_btn" class="chat-group-form__chat-group-user__btn" data-user-name="${user.name}" data-user-id="${user.id}">
           <p class="chat-group-form__chat-group-user__btn--add">追加</p>
         </a>
       </div>
       `
     return html;
   }
+// 以下、追加されたチャットメンバー欄の表示に関する記述
+  function addUserHTML(user_name, user_id){
+    var html = `
+      <div class="chat-group-form__chat-group-user">
+        <input value="${user_id}" type="hidden" name="group[user_ids][]" id="group_user_ids_${user_id}">
+        <p class="chat-group-form__chat-group-user__name">
+          ${user_name}
+        </p>
+        <a id="remove_btn" class="chat-group-form__chat-group-user__btn">
+          <p class="chat-group-form__chat-group-user__btn--remove">削除</p>
+        </a>
+      <div>
+      `
+    return html;
+  }
 
+// 以下、user検索欄に入力後の挙動に関する記述
   $('#user-search-field').on('keyup', function(e) {
     var input = $.trim($(this).val());
     $.ajax({
@@ -22,17 +39,32 @@ $(function() {
     })
 
     .then(function(users) {
-      $(".search").remove();
-      users.forEach(function(users){
-        var html = insertHTML(users);
-        $('#user-search-result').append(html);
-      });
-      if(input.length == 0){
         $(".search").remove();
-      }
+          users.forEach(function(user){
+            if ( String(user.id) !== $("#group_user_ids_" + user.id).val() ) {
+              var html = insertHTML(user);
+              $('#user-search-result').append(html);
+            }
+          });
+        // 以下、検索欄が空の時に検索結果を削除するための記述
+        if(input.length == 0){
+          $(".search").remove();
+        }
     })
   });
 
-  // $('#add_btn').on('click', function(e) {
-  // })
+// 以下、追加ボタンの挙動に関する記述
+  $('#user-search-result').on('click', '#add_btn', function(e) {
+    var user_name =  $(this).data('userName'),
+        user_id =  $(this).data('userId'),
+        html = addUserHTML(user_name, user_id);
+        $('#user-add-result').append(html);
+    $(this).parent().remove();
+  })
+
+// 以下、削除ボタンの挙動に関する記述
+  $('#user-add-result').on('click', '#remove_btn', function(e) {
+    $(this).parent().remove();
+  })
 });
+

--- a/app/assets/javascripts/group.js
+++ b/app/assets/javascripts/group.js
@@ -1,0 +1,38 @@
+$(function() {
+  function insertHTML(user) {
+    var html = `
+      <div class="chat-group-form__chat-group-user search ">
+        <p class="chat-group-form__chat-group-user__name">
+          ${user.name}
+        </p>
+        <a id="add_btn" class="chat-group-form__chat-group-user__btn">
+          <p class="chat-group-form__chat-group-user__btn--add">追加</p>
+        </a>
+      </div>
+      `
+    return html;
+  }
+
+  $('#user-search-field').on('keyup', function(e) {
+    var input = $.trim($(this).val());
+    $.ajax({
+      type: 'GET',
+      url: '/users.json',
+      data: { name: input }
+    })
+
+    .then(function(users) {
+      $(".search").remove();
+      users.forEach(function(users){
+        var html = insertHTML(users);
+        $('#user-search-result').append(html);
+      });
+      if(input.length == 0){
+        $(".search").remove();
+      }
+    })
+  });
+
+  // $('#add_btn').on('click', function(e) {
+  // })
+});

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,0 +1,11 @@
+class UsersController < ApplicationController
+
+  def index
+    @users = User.where('name LIKE(?)', "#{params[:name]}%")
+
+    respond_to do |format|
+      format.json { render json: @users }
+    end
+  end
+
+end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,7 +1,7 @@
 class UsersController < ApplicationController
 
   def index
-    @users = User.where('name LIKE(?)', "#{params[:name]}%")
+    @users = User.where('name LIKE(?)', "#{params[:name]}%").where.not(id: current_user.id)
 
     respond_to do |format|
       format.json { render json: @users }

--- a/app/views/groups/new.html.haml
+++ b/app/views/groups/new.html.haml
@@ -12,7 +12,7 @@
         = f.label :name, "チャットメンバーを追加", class: "chat-group-form__field__label"
       .chat-group-form__field--right
         .chat-group-form__search
-          = f.text_field :user_ids, id: "user-search-field", class: "chat-group-form__field__input", type: "text", placeholder: "追加したいユーザー名を入力してください"
+          = f.text_field :group_users, value: "", id: "user-search-field", class: "chat-group-form__field__input", type: "text", placeholder: "追加したいユーザー名を入力してください"
         #user-search-result
 
     .chat-group-form__field
@@ -20,9 +20,10 @@
         = f.label :name, "チャットメンバー", class: "chat-group-form__field__label"
       .chat-group-form__field--right
         .chat-group-form__chat-group-user
-          = f.hidden_field :user_ids, value: "#{current_user.id}"
+          = f.hidden_field :name, name: "group[user_ids][]", value: "#{current_user.id}"
           %p.chat-group-user__name
             = current_user.name
+        #user-add-result
 
     .chat-group-form__field
       .chat-group-form__field--left

--- a/app/views/groups/new.html.haml
+++ b/app/views/groups/new.html.haml
@@ -6,14 +6,24 @@
         = f.label :name, "グループ名", class: "chat-group-form__field__label"
       .chat-group-form__field--right
         = f.text_field :name, class: "chat-group-form__field__input", placeholder: "グループ名を入力してください"
+
+    .chat-group-form__field
+      .chat-group-form__field--left
+        = f.label :name, "チャットメンバーを追加", class: "chat-group-form__field__label"
+      .chat-group-form__field--right
+        .chat-group-form__search
+          = f.text_field :user_ids, id: "user-search-field", class: "chat-group-form__field__input", type: "text", placeholder: "追加したいユーザー名を入力してください"
+        #user-search-result
+
     .chat-group-form__field
       .chat-group-form__field--left
         = f.label :name, "チャットメンバー", class: "chat-group-form__field__label"
       .chat-group-form__field--right
-        #chat-group-users
-          #chat-group-user-22.chat-group-user
-          = f.collection_check_boxes :user_ids, User.all, :id, :name do |b|
-            - b.label { b.check_box + b.text }
+        .chat-group-form__chat-group-user
+          = f.hidden_field :user_ids, value: "#{current_user.id}"
+          %p.chat-group-user__name
+            = current_user.name
+
     .chat-group-form__field
       .chat-group-form__field--left
       .chat-group-form__field--right

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,6 @@
 Rails.application.routes.draw do
   devise_for :users
+  resources :users, only: :index
   root 'groups#index'
   resources :groups, only: [:index,:new, :edit, :create, :update] do
     resources :messages, only: [:index, :create]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,8 +1,8 @@
 Rails.application.routes.draw do
   devise_for :users
-  resources :users, only: :index
+  resources :users, except: :destroy
   root 'groups#index'
-  resources :groups, only: [:index,:new, :edit, :create, :update] do
-    resources :messages, only: [:index, :create]
+  resources :groups, only: %i(index new edit create update) do
+    resources :messages, only: %i(index create)
   end
 end


### PR DESCRIPTION
# WHAT
① collection_check_boxをinputに変更する
② inputに入力された文字をjsで取得する
③ Ajaxで取得した文字をjson形式に変換し、Userコントローラーに送信する
④ Userコントローラーで関連するユーザーを検索する → jsに返還する（current_userを除く）
⑤ 関連するユーザーをinput以下に表示する
⑥ 追加ボタンを押されたユーザーを「チャットメンバー」欄に表示する
⑦ 追加ボタンを押されたユーザーは再検索時に検索結果に表示されないようにする
⑧削除ボタンを押されたチャットメンバーは欄から消え、再検索時に検索結果に表示する
⑨ saveでグループ名、チャットメンバーを保存する
⑩ "group/group_id/messages"に遷移する
# WHY
操作性の高い仕様にするため